### PR TITLE
Add support for managing subtasks

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -206,6 +206,10 @@ label[for='toggle-all'] {
   display: none;
 }
 
+#todo-list li .view {
+  position: relative;
+}
+
 #todo-list li .toggle {
   text-align: center;
   width: 40px;

--- a/app/assets/stylesheets/subtasks.css.scss
+++ b/app/assets/stylesheets/subtasks.css.scss
@@ -1,0 +1,26 @@
+.subtasks {
+  padding-left: 40px;
+}
+
+.subtask-list {
+  list-style-type: none; 
+  padding-left: 0;
+
+  &:not(:empty) {
+    border-top: 1px dotted #ccc; 
+  }
+
+  > li > .view {
+    font-size: 80%;
+  }
+}
+
+.new_subtask input[type="text"] {
+  background-color: transparent;
+  border: 0 none;
+  display: block;
+  font-size: 16px;
+  outline: none;
+  padding: 10px 20px;
+  width:100%;
+}

--- a/app/controllers/subtasks_controller.rb
+++ b/app/controllers/subtasks_controller.rb
@@ -1,0 +1,32 @@
+class SubtasksController < ApplicationController
+  def create
+    @subtask = todo.subtasks.new(subtask_params)
+    @subtask.save
+  end
+
+  def toggle
+    subtask.toggle!(:completed)
+  end
+
+  def update
+    subtask.update(subtask_params)
+  end
+
+  def destroy
+    subtask.destroy
+  end
+
+  private
+
+  def subtask_params
+    params.require(:subtask).permit(:title, :completed)
+  end
+
+  def subtask
+    @subtask ||= todo.subtasks.find(params[:id])
+  end
+
+  def todo
+    @todo ||= Todo.find(params[:todo_id])
+  end
+end

--- a/app/models/subtask.rb
+++ b/app/models/subtask.rb
@@ -1,0 +1,10 @@
+class Subtask < ActiveRecord::Base
+  scope :completed, -> { where(completed: true) }
+  scope :active, -> { where(completed: false) }
+
+  belongs_to :todo
+
+  def title=(title)
+    write_attribute(:title, title.strip)
+  end
+end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -2,6 +2,8 @@ class Todo < ActiveRecord::Base
   scope :completed, -> { where("completed = ?", true) }
   scope :active, -> { where("completed = ?", false) }
 
+  has_many :subtasks
+
   def title=(title)
     write_attribute(:title, title.strip)
   end

--- a/app/views/subtasks/_subtask.html.erb
+++ b/app/views/subtasks/_subtask.html.erb
@@ -1,0 +1,15 @@
+<li class="<%= "completed" if subtask.completed? %>" id="<%= dom_id(subtask) %>">
+  <div class="view">
+    <%= form_for(subtask, url: toggle_todo_subtask_path(subtask.todo, subtask), method: :post, remote: true) do |f| %>
+      <%= f.check_box :completed, class: "toggle", "data-behavior" => "submit_on_check" %>
+    <% end %>
+    <label data-behavior="todo_title"><%= subtask.title %></label>
+    <%= form_for([subtask.todo, subtask], method: :delete, remote: true) do |f| %>
+      <button type="submit" class="destroy"></button>
+    <% end %>
+  </div>
+  <%= form_for([subtask.todo, subtask], remote: true, html: { "data-behavior" => "edit_todo_form" }) do |f| %>
+    <%= f.text_field :title, class: "edit", "data-behavior" => "todo_title_input", "data-original-value" => subtask.title %>
+  <% end %>
+</li>
+

--- a/app/views/subtasks/create.js.erb
+++ b/app/views/subtasks/create.js.erb
@@ -1,0 +1,3 @@
+$("#subtask-list-<%= dom_id(@subtask.todo) %>").append("<%= j(render(@subtask)) %>");
+
+$("#new-subtask-<%= dom_id(@subtask.todo) %>").val("");

--- a/app/views/subtasks/destroy.js.erb
+++ b/app/views/subtasks/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#<%= dom_id(@subtask) %>").remove();

--- a/app/views/subtasks/toggle.js.erb
+++ b/app/views/subtasks/toggle.js.erb
@@ -1,0 +1,8 @@
+$("#<%= dom_id(@subtask) %>")
+  .toggleClass("completed", <%= @subtask.completed? %>)
+  .find("input.toggle")
+  .prop("checked", <%= @subtask.completed? %>);
+
+<% if @subtask.todo.subtasks.all?(&:completed?) %>
+  $("#<%= dom_id(@subtask.todo) %>").find("input.toggle").trigger('click');
+<% end %>

--- a/app/views/subtasks/update.js.erb
+++ b/app/views/subtasks/update.js.erb
@@ -1,0 +1,1 @@
+$("#<%= dom_id(@subtask) %>").replaceWith("<%= j(render(@subtask)) %>");

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -11,4 +11,14 @@
   <%= form_for(todo, remote: true, html: { "data-behavior" => "edit_todo_form" }) do |f| %>
     <%= f.text_field :title, class: "edit", "data-behavior" => "todo_title_input", "data-original-value" => todo.title %>
   <% end %>
+
+  <div class="subtasks">
+    <%= form_for([todo, todo.subtasks.new], remote: true) do |f| %>
+      <%= f.text_field :title, placeholder: "What needs to be done?", id: "new-subtask-#{dom_id(todo)}", autofocus: true, "data-behavior" => "submit_on_enter" %>
+    <% end %>
+
+    <ul id="subtask-list-<%= dom_id(todo) %>" class="subtask-list">
+      <%= render todo.subtasks.delete_if(&:new_record?) %>
+    </ul>
+  </div>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,12 @@ Todos::Application.routes.draw do
       get :completed
       delete :destroy_completed
     end
+
+    resources :subtasks, only: [:create, :update, :destroy] do
+      member do
+        post :toggle
+      end
+    end
   end
 
   root to: "todos#index"

--- a/db/migrate/20150901183045_subtask.rb
+++ b/db/migrate/20150901183045_subtask.rb
@@ -1,0 +1,10 @@
+class Subtask < ActiveRecord::Migration
+  def change
+    create_table :subtasks do |t|
+      t.integer :todo_id, null: false
+      t.boolean :completed, default: false, null: false
+      t.string :title
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130518030840) do
+ActiveRecord::Schema.define(version: 20150901183045) do
+
+  create_table "subtasks", force: true do |t|
+    t.integer  "todo_id",                    null: false
+    t.boolean  "completed",  default: false, null: false
+    t.string   "title"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "todos", force: true do |t|
     t.boolean  "completed",  default: false, null: false


### PR DESCRIPTION
Each Todo item will display a text field below it so that subtasks can be added. Those can also be completed, edited and deleted. Completing all subtasks will complete their parent task.
